### PR TITLE
Clean dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ tiny-keccak = {version="2.0", features=["shake"]}
 rand="0.7"
 once_cell="1.2"
 bitvec="0.15"
-criterion = "0.3"
-rug = {version="1.6", features = ["integer"]}
+rug = {version="1.6", features = ["integer"], default-features = false}
 hex="0.4"
+
+[dev-dependencies]
+criterion = "0.3"
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
- criterion: (benchmarking) move to dev-dependencies
- rug: opt-out of its default features